### PR TITLE
Debounce observeActivePaneItem for speed

### DIFF
--- a/lib/fold-navigator.js
+++ b/lib/fold-navigator.js
@@ -2,6 +2,8 @@
 //showSearch
 import FoldNavigatorView from './fold-navigator-view';
 import fuzzaldrinPlus from 'fuzzaldrin-plus';
+import _ from 'lodash';
+
 
 import {
     CompositeDisposable
@@ -214,9 +216,9 @@ export default {
         }
 
         // follow cursor in fold navigator register subscription so that we can remove it
-        this.onDidChangeCursorPositionSubscription = editor.onDidChangeCursorPosition((event) => {
+        this.onDidChangeCursorPositionSubscription = editor.onDidChangeCursorPosition(_.debounce((event) => {
             this.onDidChangeCursorPosition(event);
-        });
+        }), 0.5);
 
         //dispose of previous subscription
         if (this.onDidStopChangingSubscription) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "fuzzaldrin": "^2.1.0",
-    "fuzzaldrin-plus": "^0.1.0"
+    "fuzzaldrin-plus": "^0.1.0",
+    "lodash": "^4.17.5"
   }
 }


### PR DESCRIPTION
Previously the entire nav UI is re-rendered with every keypress, making typing very slow.