### PR TITLE
Debounce observeActivePaneItem for speed, part 2

### DIFF
--- a/lib/fold-navigator.js
+++ b/lib/fold-navigator.js
@@ -216,9 +216,9 @@ export default {
         }
 
         // follow cursor in fold navigator register subscription so that we can remove it
-        this.onDidChangeCursorPositionSubscription = editor.onDidChangeCursorPosition(_.debounce((event) => {
-            this.onDidChangeCursorPosition(event);
-        }), 0.5);
+        this.onDidChangeCursorPositionSubscription = editor.onDidChangeCursorPosition(
+          _.debounce((event) => this.onDidChangeCursorPosition(event), 500)
+        );
 
         //dispose of previous subscription
         if (this.onDidStopChangingSubscription) {
@@ -226,7 +226,9 @@ export default {
         }
 
         // if document changed subscription
-        this.onDidStopChangingSubscription = editor.onDidStopChanging(() => this.parse(editor));
+        this.onDidStopChangingSubscription = editor.onDidStopChanging(
+          _.debounce((event) => this.parse(editor), 500)
+        );
 
         this.parse(editor);
     },


### PR DESCRIPTION
Fixes from issues from the previous commit cf86552fd9a41c422bceef7d8cc650cfbe03069d
- `_.debounce` takes in ms, not s
- did not debounce `onDidStopChangingSubscription`, so UI was still slow