### PR TITLE
select row without waiting for event

### DIFF
--- a/lib/fold-navigator.js
+++ b/lib/fold-navigator.js
@@ -1027,6 +1027,7 @@ export default {
         editor.scrollToCursorPosition({
             center: true
         });
+        this.selectRow(row); // select row without waiting for onDidChangeCursorPosition
     },
 
     navigatorElementOnClick() {


### PR DESCRIPTION
select row without waiting for onDidChangeCursorPosition,

another solution to quickly navigate between rows with shortcut keys, it doesn't affect response speed of manual move-cursor-events